### PR TITLE
fix: append aspnet session id filter to headers

### DIFF
--- a/src/WebFormsForCore.Web/WebFormsForCore/AspNetCoreHosting/AspNetCoreWorkerRequest.cs
+++ b/src/WebFormsForCore.Web/WebFormsForCore/AspNetCoreHosting/AspNetCoreWorkerRequest.cs
@@ -646,7 +646,25 @@ namespace System.Web.Hosting
 				}
 			}
 
-			// copy to array unknown headers
+			// append AspFilterSessionId
+            var path = Context.Request.Path.Value ?? string.Empty;
+            // Optimize for the common case where there is no cookie
+            if (path.IndexOf('(') != -1)
+            {
+                int endPos = path.LastIndexOf(")/", StringComparison.Ordinal);
+                int startPos = (endPos > 2 ? path.LastIndexOf("/(", endPos - 1, endPos, StringComparison.Ordinal) : -1);
+                if (startPos < 0) // pattern not found: common case, exit immediately
+                    return;
+
+                if (IsValidHeader(path, startPos + 2, endPos))
+                {
+                    var sessionHeader = path.Substring(startPos + 2, endPos - startPos - 2);
+                    headers.Add("AspFilterSessionId");
+                    headers.Add(sessionHeader);
+                }
+            }
+
+            // copy to array unknown headers
 
 			int n = headers.Count / 2;
 			unknownRequestHeaders = new string[n][];
@@ -659,6 +677,45 @@ namespace System.Web.Hosting
 				unknownRequestHeaders[i][1] = headers[j++];
 			}
 		}
+
+        // Make sure sub-string if of the pattern: A(XXXX)N(XXXXX)P(XXXXX) and so on.
+        static private bool IsValidHeader(string path, int startPos, int endPos)
+        {
+            if (endPos - startPos < 3) // Minimum len is "X()"
+                return false;
+
+            while (startPos <= endPos - 3) { // Each iteration deals with one "A(XXXX)" pattern
+
+                if (path[startPos] < 'A' || path[startPos] > 'Z') // Make sure pattern starts with a capital letter
+                    return false;
+
+                if (path[startPos + 1] != '(') // Make sure next char is '('
+                    return false;
+
+                startPos += 2;
+                bool found = false;
+                for (; startPos < endPos; startPos++) { // Find the ending ')'
+
+                    if (path[startPos] == ')') { // found it!
+                        startPos++; // Set position for the next pattern
+                        found = true;
+                        break; // Break out of this for-loop.
+                    }
+
+                    if (path[startPos] == '/') { // Can't contain path separaters
+                        return false;
+                    }
+                }
+                if (!found)  {
+                    return false; // Ending ')' not found!
+                }
+            }
+
+            if (startPos < endPos) // All chars consumed?
+                return false;
+
+            return true;
+        }
 
 		private void ParsePostedContent()
 		{

--- a/src/WebFormsForCore.Web/WebFormsForCore/AspNetCoreHosting/AspNetCoreWorkerRequest.cs
+++ b/src/WebFormsForCore.Web/WebFormsForCore/AspNetCoreHosting/AspNetCoreWorkerRequest.cs
@@ -644,9 +644,9 @@ namespace System.Web.Hosting
 					headers.Add(name);
 					headers.Add(str);
 				}
-			}
-
-			// append AspFilterSessionId
+			} 
+            
+            // append AspFilterSessionId
             var path = Context.Request.Path.Value ?? string.Empty;
             // Optimize for the common case where there is no cookie
             if (path.IndexOf('(') != -1)
@@ -665,7 +665,6 @@ namespace System.Web.Hosting
             }
 
             // copy to array unknown headers
-
 			int n = headers.Count / 2;
 			unknownRequestHeaders = new string[n][];
 			int j = 0;


### PR DESCRIPTION
Session filters don't work correctly.
In my application I have session filters which create urls like: "/(S(ij5ydyyfms5awpncczvvxnux))/MainPage.aspx"
Looks like when IIS7WorkerRequest.cs is reading headers:
https://github.com/microsoft/referencesource/blob/main/System.Web/Hosting/IIS7WorkerRequest.cs#L1250

it uses native method MgdGetServerVariableW which automagically appends AspFilterSessionId to headers if it's in request path... (I doubled checked that browser doesn't send this header).
The logic that I added is based on:
https://github.com/microsoft/referencesource/blob/f7df9e2399ecd273e90908ac11caf1433e142448/System.Web/Security/CookielessHelper.cs#L68

Works fine for test app and my application.