### PR TITLE
feat: add svg and webp mime types

### DIFF
--- a/src/WebFormsForCore.Web/MimeMapping.cs
+++ b/src/WebFormsForCore.Web/MimeMapping.cs
@@ -352,6 +352,7 @@ namespace System.Web {
                 AddMapping(".stl", "application/vnd.ms-pki.stl");
                 AddMapping(".sv4cpio", "application/x-sv4cpio");
                 AddMapping(".sv4crc", "application/x-sv4crc");
+                AddMapping(".svg", "image/svg+xml");
                 AddMapping(".swf", "application/x-shockwave-flash");
                 AddMapping(".t", "application/x-troff");
                 AddMapping(".tar", "application/x-tar");
@@ -390,6 +391,7 @@ namespace System.Web {
                 AddMapping(".wbmp", "image/vnd.wap.wbmp");
                 AddMapping(".wcm", "application/vnd.ms-works");
                 AddMapping(".wdb", "application/vnd.ms-works");
+                AddMapping(".webp", "image/webp");
                 AddMapping(".wks", "application/vnd.ms-works");
                 AddMapping(".wm", "video/x-ms-wm");
                 AddMapping(".wma", "audio/x-ms-wma");


### PR DESCRIPTION
I'm not sure why adding to web.config <staticContent> section with new mime types doesn't work.
Could it be because we're always using the normal mapper instead of MimeMappingDictionaryIntegrated?
Maybe at some point it would be better to switch to asp.net core mime types as they're probably more up to date.