### PR TITLE
fix: [WebMethod] calling

### DIFF
--- a/src/WebFormsForCore.TestApp/About.aspx.cs
+++ b/src/WebFormsForCore.TestApp/About.aspx.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Web;
+using System.Web.Services;
 using System.Web.UI;
 using System.Web.UI.WebControls;
 
@@ -13,5 +14,11 @@ namespace EstrellasDeEsperanza.WebFormsForCore.TestApp
 		{
 
 		}
+
+        [WebMethod]
+        public static void TestMethod()
+        {
+            HttpContext.Current.Response.Write("ok");
+        }
 	}
 }

--- a/src/WebFormsForCore.Web/WebFormsForCore/AspNetCoreHosting/AspNetCoreWorkerRequest.cs
+++ b/src/WebFormsForCore.Web/WebFormsForCore/AspNetCoreHosting/AspNetCoreWorkerRequest.cs
@@ -710,9 +710,9 @@ namespace System.Web.Hosting
 
 				if (lastDot >= 0 && lastSlh >= 0 && lastDot < lastSlh)
 				{
-					int ipi = path.LastIndexOf('/', lastDot);
-					filePath = path.Substring(0, ipi);
-					pathInfo = path.Substring(ipi);
+					int ipi = path[lastDot..].LastIndexOf('/') + lastDot;
+					filePath = path[..ipi];
+					pathInfo = path[ipi..];
 				}
 				else
 				{


### PR DESCRIPTION
Handle calls like: About.aspx/TestMethod

1. Allow  in IsLegacyRequest urls where .aspx might be behind method name
2. Fix path info usage that is later used to determine which rest method to call:
```path.LastIndexOf('/', lastDot);```
second parameter means startIndex so it actually starts going from lastDot until the start of string (backwards).
I just used index accessor for simplicity.
3. I also did an early exist in IsLegacyRequest to avoid checks if we know it's allowed.
if (HandleAllRequestsWithWebForms)
                return true;