### PR TITLE
Fix nupkg restore path and Web.config casing

### DIFF
--- a/src/WebFormsForCore.Configuration/WebFormsForCore.Configuration.csproj
+++ b/src/WebFormsForCore.Configuration/WebFormsForCore.Configuration.csproj
@@ -33,7 +33,7 @@
         <EmbedUntrackedSources>false</EmbedUntrackedSources>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-        <RestoreSources>$(RestoreSources);../../../nupkg;https://api.nuget.org/v3/index.json</RestoreSources>
+        <RestoreSources>$(RestoreSources);../../nupkg;https://api.nuget.org/v3/index.json</RestoreSources>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/WebFormsForCore.TestApp/WebFormsForCore.TestApp.csproj
+++ b/src/WebFormsForCore.TestApp/WebFormsForCore.TestApp.csproj
@@ -151,7 +151,7 @@
     </Target>
 
     <Target Name="CopyWebConfig" AfterTargets="Build">
-        <Copy SourceFiles="Core.Web.Config" DestinationFiles="bin_dotnet\Web.config" />
+        <Copy SourceFiles="Core.Web.config" DestinationFiles="bin_dotnet\Web.config" />
     </Target>
 
     <Target Name="CopyjQuery" AfterTargets="Build">


### PR DESCRIPTION
## Summary
- Fixed `WebFormsForCore.Configuration.csproj` `RestoreSources` — the relative path to the local `nupkg` folder was off by one directory level (`../../../nupkg` → `../../nupkg`), so it never resolved on a fresh clone.
- Fixed `WebFormsForCore.TestApp.csproj` `CopyWebConfig` target — it referenced `Core.Web.Config` but the file on disk is `Core.Web.config`; this only worked on case-insensitive (Windows) filesystems and failed on Linux/macOS.

## Test plan
- [x] `dotnet build` on `WebFormsForCore.Configuration.csproj` — succeeds, restore log confirms it resolves the `nupkg` source to the repo root.
- [x] `dotnet build` on `WebFormsForCore.TestApp.csproj` — succeeds, `bin_dotnet/Web.config` is produced by the `CopyWebConfig` target.